### PR TITLE
Added ability to export PHP_CodeCoverage object to .smart format

### DIFF
--- a/src/BaseCommand.php
+++ b/src/BaseCommand.php
@@ -223,10 +223,10 @@ abstract class BaseCommand extends AbstractCommand
                 "\nGenerating code coverage report in PHPSmart format ..."
             );
 
-	    $writer = new PHP_CodeCoverage_Report_PHPSmart;
+            $writer = new PHP_CodeCoverage_Report_PHPSmart;
             $writer->process($coverage, $input->getOption('phpsmart'));
 
-	    $output->write(" done\n");
+            $output->write(" done\n");
         }
 
 

--- a/src/ExecuteCommand.php
+++ b/src/ExecuteCommand.php
@@ -117,13 +117,13 @@ class ExecuteCommand extends BaseCommand
                  null,
                  InputOption::VALUE_REQUIRED,
                  'Serialize PHP_CodeCoverage object to file'
-	     )
-	     ->addOption(
-		 'phpsmart',
-		 null,
-		 InputOption::VALUE_REQUIRED,
-		 'Export PHP_CodeCoverage object to .smart file'
-	     )
+             )
+             ->addOption(
+                 'phpsmart',
+                 null,
+                 InputOption::VALUE_REQUIRED,
+                 'Export PHP_CodeCoverage object to .smart file'
+             )
              ->addOption(
                  'text',
                  null,

--- a/src/MergeCommand.php
+++ b/src/MergeCommand.php
@@ -118,16 +118,16 @@ class MergeCommand extends BaseCommand
             array($input->getArgument('directory')), array(), array('*.cov', '*.smart')
         );
 
-    foreach ($finder->findFiles() as $file) {
-        $extension = pathinfo($file, PATHINFO_EXTENSION);
-        switch ($extension) {
-            case 'smart':
-                $object = include($file);
-                $coverage->merge($object);
-                unset($object);
-                break;
-            default:
-                $coverage->merge(unserialize(file_get_contents($file)));
+        foreach ($finder->findFiles() as $file) {
+            $extension = pathinfo($file, PATHINFO_EXTENSION);
+            switch ($extension) {
+                case 'smart':
+                    $object = include($file);
+                    $coverage->merge($object);
+                    unset($object);
+                    break;
+                default:
+                    $coverage->merge(unserialize(file_get_contents($file)));
             }
         }
         $this->handleReports($coverage, $input, $output);


### PR DESCRIPTION
Export and import for PHP_CodeCoverage in our project was too long - approx 70 hours. With changing serialize/unserialize approach we've got 2.5 hours. New approach is var_export and include.
