### PR TITLE
fix fatal error on php 5.3

### DIFF
--- a/src/BaseCommand.php
+++ b/src/BaseCommand.php
@@ -141,7 +141,8 @@ abstract class BaseCommand extends AbstractCommand
     {
         $filter = $coverage->filter();
 
-        if (empty($input->getOption('whitelist'))) {
+        $whitelist = $input->getOption('whitelist');
+        if (empty($whitelist)) {
             $classes = array(
                 'SebastianBergmann\PHPCOV\Application',
                 'SebastianBergmann\FinderFacade\FinderFacade',


### PR DESCRIPTION
php 5.3 not allowed function call in empty()
