### PR TITLE
Merge command doesn't merge

### DIFF
--- a/src/MergeCommand.php
+++ b/src/MergeCommand.php
@@ -106,7 +106,7 @@ class MergeCommand extends BaseCommand
      */
     protected function execute(InputInterface $input, OutputInterface $output)
     {
-        $coverage = new PHP_CodeCoverage;
+        $mergedCoverage = new PHP_CodeCoverage;
 
         $finder = new FinderFacade(
             array($input->getArgument('directory')),
@@ -116,10 +116,10 @@ class MergeCommand extends BaseCommand
 
         foreach ($finder->findFiles() as $file) {
             $_coverage = include($file);
-            $coverage->merge($_coverage);
+            $mergedCoverage->merge($_coverage);
             unset($_coverage);
         }
 
-        $this->handleReports($coverage, $input, $output);
+        $this->handleReports($mergedCoverage, $input, $output);
     }
 }


### PR DESCRIPTION
The variable to export the Coverage object inside the *.cov files was named $coverage and was overwriting the $coverage variable in MergeCommend::execute(). The result is that only the last file is in the merge result.
By renaming $coverage to $mergedCoverage this bug is avoided.
