### PR TITLE
Adds error handling for coverage merging

### DIFF
--- a/src/MergeCommand.php
+++ b/src/MergeCommand.php
@@ -60,6 +60,11 @@ use PHP_CodeCoverage;
 class MergeCommand extends BaseCommand
 {
     /**
+     * @var string[]
+     */
+    protected $mergeErrors;
+
+    /**
      * Configures the current command.
      */
     protected function configure()
@@ -122,10 +127,35 @@ class MergeCommand extends BaseCommand
 
         foreach ($finder->findFiles() as $file) {
             $_coverage = include($file);
+            
+            if (! ($_coverage instanceof PHP_CodeCoverage)) {
+                $this->mergeErrors[] = $file;
+                unset($_coverage);
+                continue;
+            }
+            
             $mergedCoverage->merge($_coverage);
             unset($_coverage);
         }
 
         $this->handleReports($mergedCoverage, $input, $output);
+        $this->outputMergeErrors($output);
+    }
+
+    /**
+     * 
+     * @param OutputInterface $output
+     * 
+     * @return void
+     */
+    protected function outputMergeErrors(OutputInterface $output)
+    {
+        if (empty($this->mergeErrors)) {
+            return;
+        }
+
+        foreach ($this->mergeErrors as $mergeError) {
+             $output->write('Failed to merge: '. $mergeError, true);
+        }
     }
 }


### PR DESCRIPTION
I had some trouble with a .cov file generated by a parallel test run, and phpcov would just blow up when it hit the file in question. I added a patch to make it store the name of the invalid file, and output a list of failed merge files at the end.