### PR TITLE
PatchCoverage now checks new file name, and new start number for chunks

### DIFF
--- a/src/PatchCoverage.php
+++ b/src/PatchCoverage.php
@@ -36,6 +36,7 @@
  *
  * @package   phpcov
  * @author    Sebastian Bergmann <sebastian@phpunit.de>
+ * @author    Rob Caiger <rob@clocal.co.uk>
  * @copyright 2011-2014 Sebastian Bergmann <sebastian@phpunit.de>
  * @license   http://www.opensource.org/licenses/BSD-3-Clause  The BSD 3-Clause License
  * @since     File available since Release 2.0.0
@@ -48,6 +49,7 @@ use SebastianBergmann\Diff\Parser as DiffParser;
 
 /**
  * @author    Sebastian Bergmann <sebastian@phpunit.de>
+ * @author    Rob Caiger <rob@clocal.co.uk>
  * @copyright 2011-2014 Sebastian Bergmann <sebastian@phpunit.de>
  * @license   http://www.opensource.org/licenses/BSD-3-Clause  The BSD 3-Clause License
  * @link      http://github.com/sebastianbergmann/php-code-coverage/tree
@@ -76,7 +78,7 @@ class PatchCoverage
         $changes  = array();
 
         foreach ($patch as $diff) {
-            $file           = substr($diff->getFrom(), 2);
+            $file           = substr($diff->getTo(), 2);
             $changes[$file] = array();
 
             foreach ($diff->getChunks() as $chunk) {
@@ -98,6 +100,7 @@ class PatchCoverage
             $key = $prefix . $file;
 
             foreach ($lines as $line) {
+
                 if (isset($coverage[$key][$line]) &&
                     is_array($coverage[$key][$line])) {
                     $result['numChangedLinesThatAreExecutable']++;

--- a/src/PatchCoverage.php
+++ b/src/PatchCoverage.php
@@ -36,7 +36,6 @@
  *
  * @package   phpcov
  * @author    Sebastian Bergmann <sebastian@phpunit.de>
- * @author    Rob Caiger <rob@clocal.co.uk>
  * @copyright 2011-2014 Sebastian Bergmann <sebastian@phpunit.de>
  * @license   http://www.opensource.org/licenses/BSD-3-Clause  The BSD 3-Clause License
  * @since     File available since Release 2.0.0
@@ -49,7 +48,6 @@ use SebastianBergmann\Diff\Parser as DiffParser;
 
 /**
  * @author    Sebastian Bergmann <sebastian@phpunit.de>
- * @author    Rob Caiger <rob@clocal.co.uk>
  * @copyright 2011-2014 Sebastian Bergmann <sebastian@phpunit.de>
  * @license   http://www.opensource.org/licenses/BSD-3-Clause  The BSD 3-Clause License
  * @link      http://github.com/sebastianbergmann/php-code-coverage/tree

--- a/src/PatchCoverage.php
+++ b/src/PatchCoverage.php
@@ -82,7 +82,7 @@ class PatchCoverage
             $changes[$file] = array();
 
             foreach ($diff->getChunks() as $chunk) {
-                $lineNr = $chunk->getStart();
+                $lineNr = $chunk->getEnd();
 
                 foreach ($chunk->getLines() as $line) {
                     if ($line->getType() == Line::ADDED) {

--- a/tests/PatchCoverageTest.php
+++ b/tests/PatchCoverageTest.php
@@ -89,6 +89,10 @@ class PatchCoverageTest extends PHPUnit_Framework_TestCase
             // Patch showing a renamed file
             array(
                 'patch2'
+            ),
+            // Patch with different start and end numbers
+            array(
+                'patch3'
             )
         );
     }

--- a/tests/PatchCoverageTest.php
+++ b/tests/PatchCoverageTest.php
@@ -36,7 +36,6 @@
  *
  * @package   phpcov
  * @author    Sebastian Bergmann <sebastian@phpunit.de>
- * @author    Rob Caiger <rob@clocal.co.uk>
  * @copyright 2011-2014 Sebastian Bergmann <sebastian@phpunit.de>
  * @license   http://www.opensource.org/licenses/BSD-3-Clause  The BSD 3-Clause License
  * @since     File available since Release 2.0.0
@@ -48,7 +47,6 @@ use PHPUnit_Framework_TestCase;
 
 /**
  * @author    Sebastian Bergmann <sebastian@phpunit.de>
- * @author    Rob Caiger <rob@clocal.co.uk>
  * @copyright 2011-2014 Sebastian Bergmann <sebastian@phpunit.de>
  * @license   http://www.opensource.org/licenses/BSD-3-Clause  The BSD 3-Clause License
  * @link      http://github.com/sebastianbergmann/php-code-coverage/tree

--- a/tests/PatchCoverageTest.php
+++ b/tests/PatchCoverageTest.php
@@ -36,6 +36,7 @@
  *
  * @package   phpcov
  * @author    Sebastian Bergmann <sebastian@phpunit.de>
+ * @author    Rob Caiger <rob@clocal.co.uk>
  * @copyright 2011-2014 Sebastian Bergmann <sebastian@phpunit.de>
  * @license   http://www.opensource.org/licenses/BSD-3-Clause  The BSD 3-Clause License
  * @since     File available since Release 2.0.0
@@ -47,6 +48,7 @@ use PHPUnit_Framework_TestCase;
 
 /**
  * @author    Sebastian Bergmann <sebastian@phpunit.de>
+ * @author    Rob Caiger <rob@clocal.co.uk>
  * @copyright 2011-2014 Sebastian Bergmann <sebastian@phpunit.de>
  * @license   http://www.opensource.org/licenses/BSD-3-Clause  The BSD 3-Clause License
  * @link      http://github.com/sebastianbergmann/php-code-coverage/tree
@@ -54,7 +56,10 @@ use PHPUnit_Framework_TestCase;
  */
 class PatchCoverageTest extends PHPUnit_Framework_TestCase
 {
-    public function testPatchCoverageIsCalculatedCorrectly()
+    /**
+     * @dataProvider providerForPatchCoverageIsCalculatedCorrectly
+     */
+    public function testPatchCoverageIsCalculatedCorrectly($patchFile)
     {
         $pc = new PatchCoverage;
 
@@ -68,8 +73,22 @@ class PatchCoverageTest extends PHPUnit_Framework_TestCase
             ),
             $pc->execute(
                 __DIR__ . '/fixture/coverage.php',
-                __DIR__ . '/fixture/patch.txt',
+                __DIR__ . '/fixture/' . $patchFile . '.txt',
                 '/tmp/example/'
+            )
+        );
+    }
+
+    public function providerForPatchCoverageIsCalculatedCorrectly()
+    {
+        return array(
+            // Original patch
+            array(
+                'patch'
+            ),
+            // Patch showing a renamed file
+            array(
+                'patch2'
             )
         );
     }

--- a/tests/fixture/patch2.txt
+++ b/tests/fixture/patch2.txt
@@ -1,0 +1,18 @@
+diff --git a/Example.php b/Example.php
+index c566258..3e248ce 100644
+--- a/OldExample.php
++++ b/Example.php
+@@ -3,11 +3,11 @@ class Example
+ {
+     public function foo()
+     {
+-        return 'bar';
++        return 'foo';
+     }
+
+     public function bar()
+     {
+-        return 'foo';
++        return 'bar';
+     }
+ }

--- a/tests/fixture/patch3.txt
+++ b/tests/fixture/patch3.txt
@@ -2,7 +2,7 @@ diff --git a/OldExample.php b/Example.php
 index c566258..3e248ce 100644
 --- a/OldExample.php
 +++ b/Example.php
-@@ -3,11 +3,11 @@ class Example
+@@ -1,11 +3,11 @@ class Example
  {
      public function foo()
      {


### PR DESCRIPTION
This tweaks the patch coverage class, so that it reads the new file name, rather than the old file name in case of a moved file in git.

This also fixes an issue where the wrong line numbers are being output. If there are multiple chunks in a given patch that add/remove lines, the later chunks patch coverage line numbers become mis-aligned