### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ Make sure you have `~/.composer/vendor/bin/` in your path.
     $ phpunit --coverage-php /tmp/coverage.cov
 
     $ phpcov patch-coverage --patch /tmp/patch.txt         \
-                            --path-prefix /path/to/project \
+                            --path-prefix /path/to/project/ \
                             /tmp/coverage.cov
     phpcov 2.0.0 by Sebastian Bergmann.
 


### PR DESCRIPTION
Trailing slash is required or it will not concatenate path correctly and could not map it to coverage data and result will looks like

```
phpcov 2.0.1 by Sebastian Bergmann.


0 / 0 changed executable lines covered ()
```