### PR TITLE
Composer > Bumped phpunit and php-code-coverage versions

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,8 +15,8 @@
     },
     "require": {
         "php": ">=5.3.3",
-        "phpunit/phpunit": ">=4.1",
-        "phpunit/php-code-coverage": "~2.0",
+        "phpunit/phpunit": "~5.0",
+        "phpunit/php-code-coverage": "~3.0",
         "sebastian/diff": "~1.1",
         "sebastian/finder-facade": "~1.1",
         "sebastian/version": "~1.0",


### PR DESCRIPTION
See #38

This PR bumps the versions. It solves my problems (can't install phpcov with phpunit 5). 

Could you please tag a new release after merging? :)