### PR TITLE
Fixed text reporting (missing constructor arguments)

### DIFF
--- a/src/BaseCommand.php
+++ b/src/BaseCommand.php
@@ -173,7 +173,10 @@ abstract class BaseCommand extends AbstractCommand
                 "\nGenerating code coverage report in HTML format ..."
             );
 
-            $writer = new PHP_CodeCoverage_Report_HTML;
+            $writer = new PHP_CodeCoverage_Report_HTML(
+                $input->getOption('low-upper-bound'),
+                $input->getOption('high-lower-bound')
+            );
             $writer->process($coverage, $input->getOption('html'));
 
             $output->write(" done\n");
@@ -191,7 +194,12 @@ abstract class BaseCommand extends AbstractCommand
         }
 
         if ($input->getOption('text')) {
-            $writer = new PHP_CodeCoverage_Report_Text;
+            $writer = new PHP_CodeCoverage_Report_Text(
+                $input->getOption('low-upper-bound'),
+                $input->getOption('high-lower-bound'),
+                $input->getOption('show-uncovered-files'),
+                $input->getOption('show-only-summary')
+            );
             $writer->process($coverage, $input->getOption('text'));
         }
     }

--- a/src/BaseCommand.php
+++ b/src/BaseCommand.php
@@ -200,7 +200,8 @@ abstract class BaseCommand extends AbstractCommand
                 $input->getOption('show-uncovered-files'),
                 $input->getOption('show-only-summary')
             );
-            $writer->process($coverage, $input->getOption('text'));
+            $report = $writer->process($coverage, $input->getOption('text'));
+            $output->write($report);
         }
     }
 }

--- a/src/BaseCommand.php
+++ b/src/BaseCommand.php
@@ -200,7 +200,7 @@ abstract class BaseCommand extends AbstractCommand
                 $input->getOption('show-uncovered-files'),
                 $input->getOption('show-only-summary')
             );
-            $report = $writer->process($coverage, $input->getOption('text'));
+            $report = $writer->process($coverage, $input->getOption('show-colors'));
             $output->write($report);
         }
     }

--- a/src/ExecuteCommand.php
+++ b/src/ExecuteCommand.php
@@ -89,7 +89,7 @@ class ExecuteCommand extends BaseCommand
              ->addOption(
                  'text',
                  null,
-                 InputOption::VALUE_REQUIRED,
+                 InputOption::VALUE_NONE,
                  'Generate code coverage report in text format'
              )
              ->addOption(
@@ -117,6 +117,12 @@ class ExecuteCommand extends BaseCommand
                  null,
                  InputOption::VALUE_NONE,
                  'Show only the summary in --text output.'
+             )
+             ->addOption(
+                 'show-colors',
+                 null,
+                 InputOption::VALUE_NONE,
+                 'Use colored output in --text output.'
              );
     }
 

--- a/src/ExecuteCommand.php
+++ b/src/ExecuteCommand.php
@@ -98,6 +98,7 @@ class ExecuteCommand extends BaseCommand
                  InputOption::VALUE_REQUIRED,
                  'Maximum coverage percentage to be considered "lowly" covered.',
                  50
+             )
              ->addOption(
                  'high-lower-bound',
                  null,

--- a/src/ExecuteCommand.php
+++ b/src/ExecuteCommand.php
@@ -91,6 +91,31 @@ class ExecuteCommand extends BaseCommand
                  null,
                  InputOption::VALUE_REQUIRED,
                  'Generate code coverage report in text format'
+             )
+             ->addOption(
+                 'low-upper-bound',
+                 null,
+                 InputOption::VALUE_REQUIRED,
+                 'Maximum coverage percentage to be considered "lowly" covered.',
+                 50
+             ->addOption(
+                 'high-lower-bound',
+                 null,
+                 InputOption::VALUE_REQUIRED,
+                 'Minimum coverage percentage to be considered "highly" covered.',
+                 90
+             )
+             ->addOption(
+                 'show-uncovered-files',
+                 null,
+                 InputOption::VALUE_NONE,
+                 'Show all whitelisted files in --text output not just the ones with coverage information.'
+             )
+             ->addOption(
+                 'show-only-summary',
+                 null,
+                 InputOption::VALUE_NONE,
+                 'Show only the summary in --text output.'
              );
     }
 

--- a/src/MergeCommand.php
+++ b/src/MergeCommand.php
@@ -67,6 +67,31 @@ class MergeCommand extends BaseCommand
                  null,
                  InputOption::VALUE_REQUIRED,
                  'Generate code coverage report in text format'
+             )
+             ->addOption(
+                 'low-upper-bound',
+                 null,
+                 InputOption::VALUE_REQUIRED,
+                 'Maximum coverage percentage to be considered "lowly" covered.',
+                 50
+             ->addOption(
+                 'high-lower-bound',
+                 null,
+                 InputOption::VALUE_REQUIRED,
+                 'Minimum coverage percentage to be considered "highly" covered.',
+                 90
+             )
+             ->addOption(
+                 'show-uncovered-files',
+                 null,
+                 InputOption::VALUE_NONE,
+                 'Show all whitelisted files in --text output not just the ones with coverage information.'
+             )
+             ->addOption(
+                 'show-only-summary',
+                 null,
+                 InputOption::VALUE_NONE,
+                 'Show only the summary in --text output.'
              );
     }
 

--- a/src/MergeCommand.php
+++ b/src/MergeCommand.php
@@ -74,6 +74,7 @@ class MergeCommand extends BaseCommand
                  InputOption::VALUE_REQUIRED,
                  'Maximum coverage percentage to be considered "lowly" covered.',
                  50
+             )
              ->addOption(
                  'high-lower-bound',
                  null,

--- a/src/MergeCommand.php
+++ b/src/MergeCommand.php
@@ -65,7 +65,7 @@ class MergeCommand extends BaseCommand
              ->addOption(
                  'text',
                  null,
-                 InputOption::VALUE_REQUIRED,
+                 InputOption::VALUE_NONE,
                  'Generate code coverage report in text format'
              )
              ->addOption(
@@ -93,6 +93,12 @@ class MergeCommand extends BaseCommand
                  null,
                  InputOption::VALUE_NONE,
                  'Show only the summary in --text output.'
+             )
+             ->addOption(
+                 'show-colors',
+                 null,
+                 InputOption::VALUE_NONE,
+                 'Use colored output in --text output.'
              );
     }
 


### PR DESCRIPTION
Arguments for constructor of `PHP_CodeCoverage_Report_Text` were missing and they are required.

When running `phpcov` I got this:

```
$ php ./vendor/bin/phpcov merge --text true --html tests/coverage tests/coverage
phpcov 3.0.0 by Sebastian Bergmann.


Generating code coverage report in HTML format ... done
PHP Warning:  Missing argument 1 for PHP_CodeCoverage_Report_Text::__construct(), called in /Users/michal/Developer/WebDeveloper/Neverbland/CMSAdmin/backend/vendor/phpunit/phpcov/src/BaseCommand.php on line 194 and defined in /Users/michal/Developer/WebDeveloper/Neverbland/CMSAdmin/backend/vendor/phpunit/php-code-coverage/src/CodeCoverage/Report/Text.php on line 34
PHP Stack trace:
PHP   1. {main}() /Users/michal/Developer/WebDeveloper/Neverbland/CMSAdmin/backend/vendor/phpunit/phpcov/phpcov:0
PHP   2. Symfony\Component\Console\Application->run() /Users/michal/Developer/WebDeveloper/Neverbland/CMSAdmin/backend/vendor/phpunit/phpcov/phpcov:31
PHP   3. SebastianBergmann\PHPCOV\Application->doRun() /Users/michal/Developer/WebDeveloper/Neverbland/CMSAdmin/backend/vendor/symfony/console/Application.php:117
PHP   4. Symfony\Component\Console\Application->doRun() /Users/michal/Developer/WebDeveloper/Neverbland/CMSAdmin/backend/vendor/phpunit/phpcov/src/Application.php:59
PHP   5. Symfony\Component\Console\Application->doRunCommand() /Users/michal/Developer/WebDeveloper/Neverbland/CMSAdmin/backend/vendor/symfony/console/Application.php:186
PHP   6. Symfony\Component\Console\Command\Command->run() /Users/michal/Developer/WebDeveloper/Neverbland/CMSAdmin/backend/vendor/symfony/console/Application.php:791
PHP   7. SebastianBergmann\PHPCOV\MergeCommand->execute() /Users/michal/Developer/WebDeveloper/Neverbland/CMSAdmin/backend/vendor/symfony/console/Command/Command.php:256
PHP   8. SebastianBergmann\PHPCOV\BaseCommand->handleReports() /Users/michal/Developer/WebDeveloper/Neverbland/CMSAdmin/backend/vendor/phpunit/phpcov/src/MergeCommand.php:104
PHP   9. PHP_CodeCoverage_Report_Text->__construct() /Users/michal/Developer/WebDeveloper/Neverbland/CMSAdmin/backend/vendor/phpunit/phpcov/src/BaseCommand.php:194
```

and so on (many more errors).

This PR fixes it by passing the required constructor arguments based on few added CLI options - and their default values based on PHPUnit values.

The added options are:

- `--low-upper-bound` - default: `50`
- `--high-lower-bound` - default: `90`
- `--show-uncovered-files`
- `--show-only-summary`
- `--show-colors`

The last 3 only apply to `--text` report.

I also fixed an issue that `Text` report was not displaying - as the writer just returns a string to be output, doesn't write to stdout itself.

And finally I slightly changed behavior of `--text` option - it longer requires a value, but instead it is possible to configure whether it should use colored output or not via `--show-colors` option.