### PR TITLE
Fixed displaying output of text report

### DIFF
--- a/src/BaseCommand.php
+++ b/src/BaseCommand.php
@@ -192,7 +192,8 @@ abstract class BaseCommand extends AbstractCommand
 
         if ($input->getOption('text')) {
             $writer = new PHP_CodeCoverage_Report_Text;
-            $writer->process($coverage, $input->getOption('text'));
+            $report = $writer->process($coverage, $input->getOption('text'));
+            $output->write($report);
         }
     }
 }


### PR DESCRIPTION
Fixed an issue that Text report was not displaying - as the writer just returns a string to be output, doesn't write to stdout itself.

As previously submitted in https://github.com/sebastianbergmann/phpcov/pull/46