### PR TITLE
Text reporting missing constructor arguments

### DIFF
--- a/src/BaseCommand.php
+++ b/src/BaseCommand.php
@@ -173,7 +173,10 @@ abstract class BaseCommand extends AbstractCommand
                 "\nGenerating code coverage report in HTML format ..."
             );
 
-            $writer = new PHP_CodeCoverage_Report_HTML;
+            $writer = new PHP_CodeCoverage_Report_HTML(
+                $input->getOption('low-upper-bound'),
+                $input->getOption('high-lower-bound')
+            );
             $writer->process($coverage, $input->getOption('html'));
 
             $output->write(" done\n");
@@ -191,7 +194,12 @@ abstract class BaseCommand extends AbstractCommand
         }
 
         if ($input->getOption('text')) {
-            $writer = new PHP_CodeCoverage_Report_Text;
+            $writer = new PHP_CodeCoverage_Report_Text(
+                $input->getOption('low-upper-bound'),
+                $input->getOption('high-lower-bound'),
+                $input->getOption('show-uncovered-files'),
+                $input->getOption('show-only-summary')
+            );
             $writer->process($coverage, $input->getOption('text'));
         }
     }

--- a/src/ExecuteCommand.php
+++ b/src/ExecuteCommand.php
@@ -98,6 +98,7 @@ class ExecuteCommand extends BaseCommand
                  InputOption::VALUE_REQUIRED,
                  'Maximum coverage percentage to be considered "lowly" covered.',
                  50
+             )
              ->addOption(
                  'high-lower-bound',
                  null,

--- a/src/ExecuteCommand.php
+++ b/src/ExecuteCommand.php
@@ -91,6 +91,31 @@ class ExecuteCommand extends BaseCommand
                  null,
                  InputOption::VALUE_REQUIRED,
                  'Generate code coverage report in text format'
+             )
+             ->addOption(
+                 'low-upper-bound',
+                 null,
+                 InputOption::VALUE_REQUIRED,
+                 'Maximum coverage percentage to be considered "lowly" covered.',
+                 50
+             ->addOption(
+                 'high-lower-bound',
+                 null,
+                 InputOption::VALUE_REQUIRED,
+                 'Minimum coverage percentage to be considered "highly" covered.',
+                 90
+             )
+             ->addOption(
+                 'show-uncovered-files',
+                 null,
+                 InputOption::VALUE_NONE,
+                 'Show all whitelisted files in --text output not just the ones with coverage information.'
+             )
+             ->addOption(
+                 'show-only-summary',
+                 null,
+                 InputOption::VALUE_NONE,
+                 'Show only the summary in --text output.'
              );
     }
 

--- a/src/MergeCommand.php
+++ b/src/MergeCommand.php
@@ -67,6 +67,31 @@ class MergeCommand extends BaseCommand
                  null,
                  InputOption::VALUE_REQUIRED,
                  'Generate code coverage report in text format'
+             )
+             ->addOption(
+                 'low-upper-bound',
+                 null,
+                 InputOption::VALUE_REQUIRED,
+                 'Maximum coverage percentage to be considered "lowly" covered.',
+                 50
+             ->addOption(
+                 'high-lower-bound',
+                 null,
+                 InputOption::VALUE_REQUIRED,
+                 'Minimum coverage percentage to be considered "highly" covered.',
+                 90
+             )
+             ->addOption(
+                 'show-uncovered-files',
+                 null,
+                 InputOption::VALUE_NONE,
+                 'Show all whitelisted files in --text output not just the ones with coverage information.'
+             )
+             ->addOption(
+                 'show-only-summary',
+                 null,
+                 InputOption::VALUE_NONE,
+                 'Show only the summary in --text output.'
              );
     }
 

--- a/src/MergeCommand.php
+++ b/src/MergeCommand.php
@@ -74,6 +74,7 @@ class MergeCommand extends BaseCommand
                  InputOption::VALUE_REQUIRED,
                  'Maximum coverage percentage to be considered "lowly" covered.',
                  50
+             )
              ->addOption(
                  'high-lower-bound',
                  null,


### PR DESCRIPTION
Arguments for constructor of `PHP_CodeCoverage_Report_Text` were missing and they are required.

This PR fixes it by passing the required constructor arguments based on few added CLI options - and their default values based on PHPUnit values.

The added options are:

- `--low-upper-bound` - default: `50`
- `--high-lower-bound` - default: `90`
- `--show-uncovered-files`
- `--show-only-summary`
- `--show-colors`

The last 3 only apply to `--text` report. They needed to be added as the values need to come from somewhere.

As previously submitted in https://github.com/sebastianbergmann/phpcov/pull/46