### PR TITLE
Introduced a start and stop function

### DIFF
--- a/src/Application.php
+++ b/src/Application.php
@@ -28,6 +28,8 @@ class Application extends AbstractApplication
         parent::__construct('phpcov', $version->getVersion());
 
         $this->add(new ExecuteCommand);
+        $this->add(new StartCommand);
+        $this->add(new StopCommand);
         $this->add(new MergeCommand);
         $this->add(new PatchCoverageCommand);
     }

--- a/src/ExecuteOptionsTrait.php
+++ b/src/ExecuteOptionsTrait.php
@@ -1,0 +1,98 @@
+<?php
+/**
+ * This file is part of phpcov.
+ *
+ * (c) Sebastian Bergmann <sebastian@phpunit.de>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * @author Levi Govaerts <legovaer@me.com>
+ */
+
+namespace SebastianBergmann\PHPCOV;
+
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputOption;
+
+/**
+ * @since Class available since Release 3.0.1
+ */
+trait ExecuteOptionsTrait
+{
+
+    /**
+     * Adds all execution options and arguments to the command.
+     *
+     * @param BaseCommand $object
+     *   The object that requires the options.
+     */
+    public function setExecuteOptions(BaseCommand $object)
+    {
+        $object->addArgument(
+            'script',
+            InputArgument::OPTIONAL,
+            'Script to execute'
+        )
+        ->addOption(
+            'configuration',
+            null,
+            InputOption::VALUE_REQUIRED,
+            'Read configuration from XML file'
+        )
+        ->addOption(
+            'whitelist',
+            null,
+            InputOption::VALUE_REQUIRED | InputOption::VALUE_IS_ARRAY,
+            'Add directory or file to the whitelist'
+        )
+        ->addOption(
+            'add-uncovered',
+            null,
+            InputOption::VALUE_NONE,
+            'Add whitelisted files that are not covered'
+        )
+        ->addOption(
+            'process-uncovered',
+            null,
+            InputOption::VALUE_NONE,
+            'Process whitelisted files that are not covered'
+        )
+        ->addOption(
+            'clover',
+            null,
+            InputOption::VALUE_REQUIRED,
+            'Generate code coverage report in Clover XML format'
+        )
+        ->addOption(
+            'crap4j',
+            null,
+            InputOption::VALUE_REQUIRED,
+            'Generate code coverage report in Crap4J XML format'
+        )
+        ->addOption(
+            'html',
+            null,
+            InputOption::VALUE_REQUIRED,
+            'Generate code coverage report in HTML format'
+        )
+        ->addOption(
+            'php',
+            null,
+            InputOption::VALUE_REQUIRED,
+            'Export code coverage object to file'
+        )
+        ->addOption(
+            'text',
+            null,
+            InputOption::VALUE_NONE,
+            'Write code coverage report in text format to STDOUT'
+        )
+        ->addOption(
+            'xml',
+            null,
+            InputOption::VALUE_REQUIRED,
+            'Generate code coverage report in PHPUnit XML format'
+        );
+    }
+}

--- a/src/StartCommand.php
+++ b/src/StartCommand.php
@@ -1,35 +1,36 @@
 <?php
-/*
+/**
  * This file is part of phpcov.
  *
  * (c) Sebastian Bergmann <sebastian@phpunit.de>
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.
+ *
+ * @author Levi Govaerts <legovaer@me.com>
  */
 
 namespace SebastianBergmann\PHPCOV;
 
 use SebastianBergmann\CodeCoverage\CodeCoverage;
-use Symfony\Component\Console\Exception\RuntimeException;
-use Symfony\Component\Console\Input\InputArgument;
+use SebastianBergmann\CodeCoverage\Driver\XdebugSQLite3;
 use Symfony\Component\Console\Input\InputInterface;
-use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 
 /**
- * @since Class available since Release 2.0.0
+ * @since Class available since Release 3.0.1
  */
-class ExecuteCommand extends BaseCommand
+class StartCommand extends BaseCommand
 {
-    use ExecuteOptionsTrait;
+
+    public $root;
 
     /**
      * Configures the current command.
      */
     protected function configure()
     {
-        $this->setName('execute');
+        $this->setName('start');
     }
 
     /**
@@ -42,21 +43,9 @@ class ExecuteCommand extends BaseCommand
      */
     protected function execute(InputInterface $input, OutputInterface $output)
     {
-        if (!$input->getArgument('script')) {
-            throw new RuntimeException('Not enough arguments (missing: "script").');
-        }
-
-        $coverage = new CodeCoverage;
-
-        $this->handleConfiguration($coverage, $input);
-        $this->handleFilter($coverage, $input);
-
-        $coverage->start('phpcov');
-
-        require $input->getArgument('script');
-
-        $coverage->stop();
-
-        $this->handleReports($coverage, $input, $output);
+        $coverage = new CodeCoverage(new XdebugSQLite3());
+        /** @var XdebugSQLite3 $driver */
+        $driver = $coverage->driver();
+        $driver->resetLog();
     }
 }

--- a/src/StopCommand.php
+++ b/src/StopCommand.php
@@ -1,26 +1,27 @@
 <?php
-/*
+/**
  * This file is part of phpcov.
  *
  * (c) Sebastian Bergmann <sebastian@phpunit.de>
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.
+ *
+ * @author Levi Govaerts <legovaer@me.com>
  */
 
 namespace SebastianBergmann\PHPCOV;
 
 use SebastianBergmann\CodeCoverage\CodeCoverage;
-use Symfony\Component\Console\Exception\RuntimeException;
-use Symfony\Component\Console\Input\InputArgument;
+use SebastianBergmann\CodeCoverage\Driver\XdebugSQLite3;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 
 /**
- * @since Class available since Release 2.0.0
+ * @since Class available since Release 3.0.1
  */
-class ExecuteCommand extends BaseCommand
+class StopCommand extends BaseCommand
 {
     use ExecuteOptionsTrait;
 
@@ -29,7 +30,8 @@ class ExecuteCommand extends BaseCommand
      */
     protected function configure()
     {
-        $this->setName('execute');
+        $this->setName('stop');
+        $this->setExecuteOptions($this);
     }
 
     /**
@@ -42,19 +44,13 @@ class ExecuteCommand extends BaseCommand
      */
     protected function execute(InputInterface $input, OutputInterface $output)
     {
-        if (!$input->getArgument('script')) {
-            throw new RuntimeException('Not enough arguments (missing: "script").');
-        }
-
-        $coverage = new CodeCoverage;
+        $driver = XdebugSQLite3::getInstance();
+        $coverage = new CodeCoverage($driver);
 
         $this->handleConfiguration($coverage, $input);
         $this->handleFilter($coverage, $input);
 
-        $coverage->start('phpcov');
-
-        require $input->getArgument('script');
-
+        $coverage->setCurrentId('phpcov');
         $coverage->stop();
 
         $this->handleReports($coverage, $input, $output);

--- a/src/lib/autocoverage.php
+++ b/src/lib/autocoverage.php
@@ -1,0 +1,32 @@
+<?php
+
+/**
+ * Include this in any file to start coverage, coverage will automatically end when process dies.
+ */
+require_once dirname(__FILE__).'/../../../../autoload.php';
+
+use SebastianBergmann\CodeCoverage\Driver\XdebugSQLite3 as Driver;
+use SebastianBergmann\CodeCoverage\CodeCoverage;
+
+if (Driver::isCoverageOn()) {
+    $driver = Driver::getInstance();
+    $coverage = new CodeCoverage($driver);
+    $coverage->start('phpcov');
+    register_shutdown_function('stop_coverage');
+}
+
+/**
+ * Stops the current coverage analysis.
+ */
+function stop_coverage()
+{
+    // hack until i can think of a way to run tests first and w/o exiting.
+    $autorun = function_exists('run_local_tests');
+    if ($autorun) {
+        $result = run_local_tests();
+    }
+    Driver::getInstance()->stop();
+    if ($autorun) {
+        exit($result ? 0 : 1);
+    }
+}


### PR DESCRIPTION
This PR introduces two new commands: `start` and `stop`. This will allow a user to start analyzing all executed PHP scripts between the start and the stop command. Every PHP file which needs to be analyzed needs to include the autocoverage PHP file:

`require <phpcov_directory>/src/lib/autocoverage.php`

Then a coverage analysis can be started by executing:

`phpcov start`

As soon as all php files have been executed, the coverage then can be stopped by executing

`phpcov stop`

Which accepts exactly the same arguments / options as `phpcov execute`