### PR TITLE
Color support

### DIFF
--- a/src/BaseCommand.php
+++ b/src/BaseCommand.php
@@ -147,6 +147,10 @@ abstract class BaseCommand extends AbstractCommand
             if ($input->getOption('no-ansi')){
                 $color=false;
             }
+            
+            if ($input->getOption('ansi')){
+                $color=true;
+            }
 
             $output->write($report->process($coverage, $color));
         }

--- a/src/BaseCommand.php
+++ b/src/BaseCommand.php
@@ -142,14 +142,13 @@ abstract class BaseCommand extends AbstractCommand
 
         if ($input->getOption('text')) {
             $report = new TextReport;
+            
+            $color=true;
+            if ($input->getOption('no-ansi')){
+                $color=false;
+            }
 
-            $output->write($report->process($coverage));
-        }
-        
-        if ($input->getOption('ansi')) {
-            $report = new TextReport;
-
-            $output->write($report->process($coverage, true));
+            $output->write($report->process($coverage, $color));
         }
 
         if ($input->getOption('xml')) {

--- a/src/BaseCommand.php
+++ b/src/BaseCommand.php
@@ -143,11 +143,7 @@ abstract class BaseCommand extends AbstractCommand
         if ($input->getOption('text')) {
             $report = new TextReport;
             
-            $color=true;
-            if ($input->getOption('no-ansi')){
-                $color=false;
-            }
-            
+            $color=false;
             if ($input->getOption('ansi')){
                 $color=true;
             }

--- a/src/BaseCommand.php
+++ b/src/BaseCommand.php
@@ -143,7 +143,13 @@ abstract class BaseCommand extends AbstractCommand
         if ($input->getOption('text')) {
             $report = new TextReport;
 
-            $output->write($report->process($coverage, $input->getOption('show-colors')));
+            $output->write($report->process($coverage));
+        }
+        
+        if ($input->getOption('ansi')) {
+            $report = new TextReport;
+
+            $output->write($report->process($coverage, true));
         }
 
         if ($input->getOption('xml')) {

--- a/src/BaseCommand.php
+++ b/src/BaseCommand.php
@@ -143,7 +143,7 @@ abstract class BaseCommand extends AbstractCommand
         if ($input->getOption('text')) {
             $report = new TextReport;
 
-            $output->write($report->process($coverage));
+            $output->write($report->process($coverage, $input->getOption('show-colors')));
         }
 
         if ($input->getOption('xml')) {

--- a/src/ExecuteCommand.php
+++ b/src/ExecuteCommand.php
@@ -83,7 +83,7 @@ class ExecuteCommand extends BaseCommand
             ->addOption(
                 'text',
                 null,
-                InputArgument::OPTIONAL,
+                InputOption::VALUE_OPTIONAL,
                 'Write code coverage report in text format to STDOUT'
             )
             ->addOption(

--- a/src/ExecuteCommand.php
+++ b/src/ExecuteCommand.php
@@ -83,7 +83,7 @@ class ExecuteCommand extends BaseCommand
             ->addOption(
                 'text',
                 null,
-                InputOption::VALUE_OPTIONAL,
+                InputOption::VALUE_NONE,
                 'Write code coverage report in text format to STDOUT'
             )
             ->addOption(
@@ -91,12 +91,6 @@ class ExecuteCommand extends BaseCommand
                 null,
                 InputOption::VALUE_REQUIRED,
                 'Generate code coverage report in PHPUnit XML format'
-            )
-            ->addOption(
-                'ansi',
-                null,
-                InputOption::VALUE_NONE,
-                'Generate code coverage report in text format colored output'
             );
     }
 

--- a/src/ExecuteCommand.php
+++ b/src/ExecuteCommand.php
@@ -83,7 +83,7 @@ class ExecuteCommand extends BaseCommand
             ->addOption(
                 'text',
                 null,
-                InputOption::VALUE_NONE,
+                InputOption::VALUE_REQUIRED,
                 'Write code coverage report in text format to STDOUT'
             )
             ->addOption(
@@ -91,6 +91,12 @@ class ExecuteCommand extends BaseCommand
                 null,
                 InputOption::VALUE_REQUIRED,
                 'Generate code coverage report in PHPUnit XML format'
+            )
+            ->addOption(
+                'ansi',
+                null,
+                InputOption::VALUE_NONE,
+                'Generate code coverage report in text format colored output'
             );
     }
 

--- a/src/ExecuteCommand.php
+++ b/src/ExecuteCommand.php
@@ -83,7 +83,7 @@ class ExecuteCommand extends BaseCommand
             ->addOption(
                 'text',
                 null,
-                InputOption::VALUE_REQUIRED,
+                InputArgument::OPTIONAL,
                 'Write code coverage report in text format to STDOUT'
             )
             ->addOption(

--- a/src/MergeCommand.php
+++ b/src/MergeCommand.php
@@ -65,7 +65,7 @@ class MergeCommand extends BaseCommand
             ->addOption(
                 'text',
                 null,
-                InputOption::OPTIONAL,
+                InputArgument::OPTIONAL,
                 'Generate code coverage report in text format'
             )
             ->addOption(

--- a/src/MergeCommand.php
+++ b/src/MergeCommand.php
@@ -73,6 +73,12 @@ class MergeCommand extends BaseCommand
                 null,
                 InputOption::VALUE_REQUIRED,
                 'Generate code coverage report in PHPUnit XML format'
+            )
+            ->addOption(
+                'show-colors',
+                null,
+                InputOption::VALUE_NONE,
+                'Use colored output in --text output.'
             );
     }
 

--- a/src/MergeCommand.php
+++ b/src/MergeCommand.php
@@ -65,7 +65,7 @@ class MergeCommand extends BaseCommand
             ->addOption(
                 'text',
                 null,
-                InputOption::VALUE_REQUIRED,
+                InputOption::VALUE_NONE,
                 'Generate code coverage report in text format'
             )
             ->addOption(

--- a/src/MergeCommand.php
+++ b/src/MergeCommand.php
@@ -65,7 +65,7 @@ class MergeCommand extends BaseCommand
             ->addOption(
                 'text',
                 null,
-                InputOption::VALUE_NONE,
+                InputOption::VALUE_REQUIRED,
                 'Generate code coverage report in text format'
             )
             ->addOption(
@@ -75,10 +75,10 @@ class MergeCommand extends BaseCommand
                 'Generate code coverage report in PHPUnit XML format'
             )
             ->addOption(
-                'show-colors',
+                'ansi',
                 null,
                 InputOption::VALUE_NONE,
-                'Use colored output in --text output.'
+                'Generate code coverage report in text format colored output'
             );
     }
 

--- a/src/MergeCommand.php
+++ b/src/MergeCommand.php
@@ -66,7 +66,7 @@ class MergeCommand extends BaseCommand
                 'text',
                 null,
                 InputOption::VALUE_NONE,
-                'Generate code coverage report in text format'
+                'Generate code coverage report in text format to STDOUT'
             )
             ->addOption(
                 'xml',

--- a/src/MergeCommand.php
+++ b/src/MergeCommand.php
@@ -65,7 +65,7 @@ class MergeCommand extends BaseCommand
             ->addOption(
                 'text',
                 null,
-                InputOption::VALUE_OPTIONAL,
+                InputOption::VALUE_NONE,
                 'Generate code coverage report in text format'
             )
             ->addOption(
@@ -73,12 +73,6 @@ class MergeCommand extends BaseCommand
                 null,
                 InputOption::VALUE_REQUIRED,
                 'Generate code coverage report in PHPUnit XML format'
-            )
-            ->addOption(
-                'ansi',
-                null,
-                InputOption::VALUE_NONE,
-                'Generate code coverage report in text format colored output'
             );
     }
 

--- a/src/MergeCommand.php
+++ b/src/MergeCommand.php
@@ -65,7 +65,7 @@ class MergeCommand extends BaseCommand
             ->addOption(
                 'text',
                 null,
-                InputOption::VALUE_NONE,
+                InputOption::OPTIONAL,
                 'Generate code coverage report in text format'
             )
             ->addOption(

--- a/src/MergeCommand.php
+++ b/src/MergeCommand.php
@@ -65,7 +65,7 @@ class MergeCommand extends BaseCommand
             ->addOption(
                 'text',
                 null,
-                InputArgument::OPTIONAL,
+                InputOption::VALUE_OPTIONAL,
                 'Generate code coverage report in text format'
             )
             ->addOption(


### PR DESCRIPTION
Color support by with `--ansi`

**Default no color**: `php vendor/bin/phpcov merge --text -- directory`

**With color**: `php vendor/bin/phpcov merge --text --ansi -- directory`

The fix in `execute` to no option not work to `merge` option
