### PR TITLE
Fix --text in 3.0

### DIFF
--- a/src/BaseCommand.php
+++ b/src/BaseCommand.php
@@ -142,7 +142,7 @@ abstract class BaseCommand extends AbstractCommand
 
         if ($input->getOption('text')) {
             $writer = new PHP_CodeCoverage_Report_Text;
-            $writer->process($coverage, $input->getOption('text'));
+            $output->write($writer->process($coverage));
         }
     }
 }

--- a/src/ExecuteCommand.php
+++ b/src/ExecuteCommand.php
@@ -83,7 +83,7 @@ class ExecuteCommand extends BaseCommand
              ->addOption(
                  'text',
                  null,
-                 InputOption::VALUE_REQUIRED,
+                 InputOption::VALUE_NONE,
                  'Generate code coverage report in text format'
              );
     }

--- a/src/MergeCommand.php
+++ b/src/MergeCommand.php
@@ -65,7 +65,7 @@ class MergeCommand extends BaseCommand
              ->addOption(
                  'text',
                  null,
-                 InputOption::VALUE_REQUIRED,
+                 InputOption::VALUE_NONE,
                  'Generate code coverage report in text format'
              );
     }


### PR DESCRIPTION
I've gone ahead and opened this PR which cherry picks your fix in https://github.com/sebastianbergmann/phpcov/commit/d1cac8424ac0483fdc80cf339d6cc4c30e73bb21 into the `3.0` branch. Also updates the `MergeCommand` option to allow `--text` to be passed without an argument.

If you're willing to release as a patch release to 3.0, it would be greatly appreciated. In the event I have overlooked something, please don't hesitate to let me know and I will update/close this PR.

Fixes https://github.com/sebastianbergmann/phpcov/issues/54
