### PR TITLE
Add command for checking code coverage

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,3 +69,15 @@ Make sure you have `~/.composer/vendor/bin/` in your path.
     phpcov 2.0.0 by Sebastian Bergmann.
 
     Generating code coverage report in Clover XML format ... done
+
+### Checking against a minimum code coverage target
+
+Use the check-coverage command to check for sufficient code coverage.
+If the check fails, PHPCOV will exit with status 1.
+
+    $ phpcov check-coverage tmp/coverage.cov 90
+    phpcov <unreleased> by Sebastian Bergmann.
+
+    Insufficient code coverage (90.0% required, 11.4% reached)
+    $ echo $?
+    1

--- a/src/Application.php
+++ b/src/Application.php
@@ -30,6 +30,7 @@ class Application extends AbstractApplication
         $this->add(new ExecuteCommand);
         $this->add(new MergeCommand);
         $this->add(new PatchCoverageCommand);
+        $this->add(new CheckCoverageCommand);
     }
 
     /**
@@ -56,6 +57,6 @@ class Application extends AbstractApplication
             exit;
         }
 
-        parent::doRun($input, $output);
+        return parent::doRun($input, $output);
     }
 }

--- a/src/CheckCoverageCommand.php
+++ b/src/CheckCoverageCommand.php
@@ -1,0 +1,85 @@
+<?php
+/*
+ * This file is part of phpcov.
+ *
+ * (c) Scato Eggen <scato.eggen@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace SebastianBergmann\PHPCOV;
+
+use SebastianBergmann\CodeCoverage\CodeCoverage;
+use SebastianBergmann\CodeCoverage\Util;
+use Symfony\Component\Console\Command\Command as AbstractCommand;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
+
+/**
+ * @since Class available since Release <unreleased>
+ */
+class CheckCoverageCommand extends AbstractCommand
+{
+    /**
+     * Configures the current command.
+     */
+    protected function configure()
+    {
+        $this->setName('check-coverage')
+             ->addArgument(
+                 'coverage',
+                 InputArgument::REQUIRED,
+                 'Exported code coverage object'
+             )
+             ->addArgument(
+                 'target',
+                 InputArgument::REQUIRED,
+                 'Target code coverage percentage'
+             );
+    }
+
+    /**
+     * Executes the current command.
+     *
+     * @param InputInterface  $input  An InputInterface instance
+     * @param OutputInterface $output An OutputInterface instance
+     *
+     * @return null|int null or 0 if everything went fine, or an error code
+     */
+    protected function execute(InputInterface $input, OutputInterface $output)
+    {
+        /** @var CodeCoverage $coverage */
+        $coverage = include($input->getArgument('coverage'));
+
+        $numExecutedLines = $coverage->getReport()->getNumExecutedLines();
+        $numExecutableLines = $coverage->getReport()->getNumExecutableLines();
+        $target = $input->getArgument('target');
+
+        $percentageOfExecutedLines = $numExecutedLines / $numExecutableLines * 100;
+
+        if ($percentageOfExecutedLines >= $target) {
+            $output->writeln(
+                sprintf(
+                    'Code coverage OK (%.1f%% required, %.1f%% reached)',
+                    $target,
+                    $percentageOfExecutedLines
+                )
+            );
+
+            return 0;
+        } else {
+            $output->writeln(
+                sprintf(
+                    'Insufficient code coverage (%.1f%% required, %.1f%% reached)',
+                    $target,
+                    $percentageOfExecutedLines
+                )
+            );
+
+            return 1;
+        }
+    }
+}


### PR DESCRIPTION
This PR contains a command for checking code coverage. You pass the path to a .cov file and a target percentage, and it returns an exit code 1 if the coverage is insufficient.

I've replaced any version number with `<unreleased>`. Is that okay?

See also: #50 
