### PR TITLE
add two options 

### DIFF
--- a/src/BaseCommand.php
+++ b/src/BaseCommand.php
@@ -119,8 +119,11 @@ abstract class BaseCommand extends AbstractCommand
             $output->write(
                 "\nGenerating code coverage report in HTML format ..."
             );
-
-            $writer = new HtmlReport;
+        
+            $writer = new HtmlReport(
+                $input->getOption('lowupperbound'),
+                $input->getOption('highlowerbound')
+            );
             $writer->process($coverage, $input->getOption('html'));
 
             $output->write(" done\n");

--- a/src/MergeCommand.php
+++ b/src/MergeCommand.php
@@ -36,6 +36,20 @@ class MergeCommand extends BaseCommand
                  'Directory to scan for exported code coverage objects stored in .cov files'
              )
              ->addOption(
+                 'lowupperbound',
+                 null,
+                 InputOption::VALUE_OPTIONAL,
+                 'Maximum coverage percentage to be considered "lowly" covered',
+                 50
+             )
+             ->addOption(
+                 'highlowerbound',
+                 null,
+                 InputOption::VALUE_OPTIONAL,
+                 'Minimum coverage percentage to be considered "highly" covered',
+                 90
+             )
+             ->addOption(
                  'clover',
                  null,
                  InputOption::VALUE_REQUIRED,


### PR DESCRIPTION
This PR is solve #66 .
It adds two option on command line when generating HTML report : 
--lowupperbound=nn (default : 50)
--highlowerbound=nn (default : 90)
This two values are used to define trigger level of dashboard. 