### PR TITLE
Support raw (JSON) from xdebug_get_code_coverage

### DIFF
--- a/src/PatchCoverage.php
+++ b/src/PatchCoverage.php
@@ -20,7 +20,7 @@ use SebastianBergmann\Diff\Parser as DiffParser;
 
 final class PatchCoverage
 {
-    public function execute(string $coverageFile, string $patchFile, string $pathPrefix): array
+    public function execute(string $coverageFile, string $patchFile, string $pathPrefix, string $mapFrom, string $mapTo): array
     {
         $result = [
             'numChangedLinesThatAreExecutable' => 0,
@@ -32,7 +32,7 @@ final class PatchCoverage
             $pathPrefix .= DIRECTORY_SEPARATOR;
         }
 
-        $coverage = include($coverageFile);
+        $coverage = $this->loadCodeCoverage($coverageFile, $mapFrom, $mapTo);
 
         assert($coverage instanceof CodeCoverage);
 

--- a/src/XdebugFileDriver.php
+++ b/src/XdebugFileDriver.php
@@ -1,0 +1,45 @@
+<?php
+namespace SebastianBergmann\PHPCOV;
+
+use SebastianBergmann\CodeCoverage\Driver\Driver;
+use SebastianBergmann\CodeCoverage\RawCodeCoverageData;
+
+final class XdebugFileDriver extends Driver
+{
+    public function __construct($fileName, $mapFrom = "", $mapTo = "")
+    {
+        $this->data = array();
+
+        foreach(json_decode(file_get_contents($fileName), true) as $key => $value) {
+            $this->data[str_replace($mapFrom, $mapTo, $key)] = $value;
+        }
+    }
+
+    public function canCollectBranchAndPathCoverage(): bool
+    {
+        return true;
+    }
+
+    public function canDetectDeadCode(): bool
+    {
+        return true;
+    }
+
+    public function start(): void
+    {
+    }
+
+    public function stop(): RawCodeCoverageData
+    {
+        if ($this->collectsBranchAndPathCoverage()) {
+            return RawCodeCoverageData::fromXdebugWithPathCoverage($this->data);
+        }
+
+        return RawCodeCoverageData::fromXdebugWithoutPathCoverage($this->data);
+    }
+
+    public function nameAndVersion(): string
+    {
+        return 'Xdebug file driver';
+    }
+}

--- a/src/cli/Arguments.php
+++ b/src/cli/Arguments.php
@@ -106,7 +106,17 @@ final class Arguments
      */
     private $pathPrefix;
 
-    public function __construct(?string $command, ?string $script, ?string $directory, ?string $coverage, ?string $patch, ?string $configuration, array $include, bool $pathCoverage, bool $addUncovered, bool $processUncovered, ?string $clover, ?string $cobertura, ?string $crap4j, ?string $html, ?string $php, ?string $text, ?string $xml, ?string $pathPrefix, bool $help, bool $version)
+    /**
+     * @var ?string
+     */
+    private $mapFrom;
+
+    /**
+     * @var ?string
+     */
+    private $mapTo;
+
+    public function __construct(?string $command, ?string $script, ?string $directory, ?string $coverage, ?string $patch, ?string $configuration, array $include, bool $pathCoverage, bool $addUncovered, bool $processUncovered, ?string $clover, ?string $cobertura, ?string $crap4j, ?string $html, ?string $php, ?string $text, ?string $xml, ?string $mapFrom, ?string $mapTo, ?string $pathPrefix, bool $help, bool $version)
     {
         $this->command          = $command;
         $this->script           = $script;
@@ -125,6 +135,8 @@ final class Arguments
         $this->php              = $php;
         $this->text             = $text;
         $this->xml              = $xml;
+        $this->mapFrom          = $mapFrom;
+        $this->mapTo            = $mapTo;
         $this->pathPrefix       = $pathPrefix;
         $this->help             = $help;
         $this->version          = $version;
@@ -233,5 +245,15 @@ final class Arguments
     public function reportConfigured(): bool
     {
         return $this->clover() || $this->cobertura() || $this->crap4j() || $this->html() || $this->php() || $this->text() || $this->xml();
+    }
+
+    public function mapFrom(): ?string
+    {
+        return $this->mapFrom;
+    }
+
+    public function mapTo(): ?string
+    {
+        return $this->mapTo;
     }
 }

--- a/src/cli/ArgumentsBuilder.php
+++ b/src/cli/ArgumentsBuilder.php
@@ -45,6 +45,8 @@ final class ArgumentsBuilder
                 'php=',
                 'text=',
                 'xml=',
+                'mapFrom=',
+                'mapTo=',
             ],
             'arguments' => [
                 'directory',
@@ -136,6 +138,8 @@ final class ArgumentsBuilder
         $php              = null;
         $text             = null;
         $xml              = null;
+        $mapFrom          = null;
+        $mapTo            = null;
         $pathPrefix       = null;
         $help             = false;
         $version          = false;
@@ -202,6 +206,16 @@ final class ArgumentsBuilder
 
                     break;
 
+                case '--mapFrom':
+                    $mapFrom = $option[1];
+
+                    break;
+
+                case '--mapTo':
+                    $mapTo = $option[1];
+
+                    break;
+
                 case '--path-prefix':
                     $pathPrefix = $option[1];
 
@@ -239,6 +253,8 @@ final class ArgumentsBuilder
             $php,
             $text,
             $xml,
+            $mapFrom,
+            $mapTo,
             $pathPrefix,
             $help,
             $version,

--- a/src/cli/Command.php
+++ b/src/cli/Command.php
@@ -14,6 +14,7 @@ use function file_put_contents;
 use PHPUnit\TextUI\XmlConfiguration\CodeCoverage\FilterMapper;
 use PHPUnit\TextUI\XmlConfiguration\Loader;
 use SebastianBergmann\CodeCoverage\CodeCoverage;
+use SebastianBergmann\CodeCoverage\Filter;
 use SebastianBergmann\CodeCoverage\Report\Clover as CloverReport;
 use SebastianBergmann\CodeCoverage\Report\Cobertura as CoberturaReport;
 use SebastianBergmann\CodeCoverage\Report\Crap4j as Crap4jReport;
@@ -25,6 +26,22 @@ use SebastianBergmann\CodeCoverage\Report\Xml\Facade as XmlReport;
 abstract class Command
 {
     abstract public function run(Arguments $arguments): int;
+
+    protected function loadCodeCoverage($fileName, $mapFrom, $mapTo): CodeCoverage
+    {
+        $pathParts = pathinfo($fileName);
+        switch ($pathParts["extension"]) {
+        case "json":
+            $coverage = new CodeCoverage(new XdebugFileDriver($fileName, $mapFrom, $mapTo), new Filter);
+            $coverage->start('dummy');
+            $coverage->stop();
+            break;
+        case "cov":
+            $coverage = include($fileName);
+            break;
+        }
+        return $coverage;
+    }
 
     protected function handleConfiguration(CodeCoverage $coverage, Arguments $arguments): void
     {

--- a/src/cli/MergeCommand.php
+++ b/src/cli/MergeCommand.php
@@ -37,7 +37,7 @@ final class MergeCommand extends Command
 
         $files = (new Facade)->getFilesAsArray(
             $arguments->directory(),
-            ['.cov']
+            ['.cov', '.json']
         );
 
         if (empty($files)) {
@@ -52,7 +52,7 @@ final class MergeCommand extends Command
         $errors = [];
 
         foreach ($files as $file) {
-            $_coverage = include($file);
+            $_coverage = $this->loadCodeCoverage($file, $arguments->mapFrom(), $arguments->mapTo());
 
             if (!$_coverage instanceof CodeCoverage) {
                 $errors[] = $file;

--- a/src/cli/PatchCoverageCommand.php
+++ b/src/cli/PatchCoverageCommand.php
@@ -41,7 +41,9 @@ final class PatchCoverageCommand extends Command
         $patchCoverage = (new PatchCoverage)->execute(
             $arguments->coverage(),
             $arguments->patch(),
-            $pathPrefix
+            $pathPrefix,
+            $arguments->mapFrom(),
+            $arguments->mapTo()
         );
 
         if ($patchCoverage['numChangedLinesThatWereExecuted'] === 0 &&


### PR DESCRIPTION
Before this patch only the `.cov` file format was supported, add support from `.json` files collected by serializing the output from `xdebug_get_code_coverage`.

Also allow a rewrite of the source code paths because it might be colected from a different environment (ie. bind mounts in container).

This could be useful if you want to collect coverage by only using xdebug (I'd like to use this to check/improve the coverage of integration tests):

php.ini:
```ini
auto_prepend_file = "prepend.php"
auto_append_file = "append.php"
```

prepend.php:
```php
<?php
xdebug_start_code_coverage();
```

append.php:
```php
<?php
$filename = uniqid();
file_put_contents("/var/www/html/coverage/$filename.json", json_encode(xdebug_get_code_coverage()));
```

It might make sense to add `XdebugFileDriver` to `php-code-coverage`, let me know if you'd like me to create a PR for that.