### PR TITLE
Fix namespace

### DIFF
--- a/src/cli/PatchCoverageCommand.php
+++ b/src/cli/PatchCoverageCommand.php
@@ -12,7 +12,7 @@ namespace SebastianBergmann\PHPCOV;
 use const PHP_EOL;
 use function is_file;
 use function printf;
-use SebastianBergmann\CodeCoverage\Percentage;
+use SebastianBergmann\CodeCoverage\Util\Percentage;
 
 final class PatchCoverageCommand extends Command
 {


### PR DESCRIPTION
Have been renamed in 9.2.13... (BC break)


See 0f89e2c6a099e266ddfa7422d9d849bac2d792f0