### PR TITLE
Add PHP 8.2 support

### DIFF
--- a/src/cli/Arguments.php
+++ b/src/cli/Arguments.php
@@ -69,6 +69,11 @@ final class Arguments
     /**
      * @var ?string
      */
+    private $cobertura;
+
+    /**
+     * @var ?string
+     */
     private $crap4j;
 
     /**


### PR DESCRIPTION
This PR adds PHP 8.2 support just by getting rid of the following deprecation:

```
Deprecated: Creation of dynamic property SebastianBergmann\PHPCOV\Arguments::$cobertura
is deprecated in ./phpcov/src/cli/Arguments.php on line 122
```