### PR TITLE
Enhancement: Enable `no_trailing_comma_in_singleline` fixer

### DIFF
--- a/.php-cs-fixer.dist.php
+++ b/.php-cs-fixer.dist.php
@@ -153,8 +153,7 @@ $config->setFinder($finder)
         'no_superfluous_phpdoc_tags' => [
             'allow_mixed' => true,
         ],
-        'no_trailing_comma_in_list_call' => true,
-        'no_trailing_comma_in_singleline_array' => true,
+        'no_trailing_comma_in_singleline' => true,
         'no_trailing_whitespace' => true,
         'no_trailing_whitespace_in_comment' => true,
         'no_trailing_whitespace_in_string' => true,


### PR DESCRIPTION
This pull request

- [x] enables the `no_trailing_comma_in_singleline` fixer instead of the deprecated `no_trailing_comma_in_list_call` and `no_trailing_comma_in_singleline_array` fixers

💁‍♂️ Running

```shell
tools/php-cs-fixer fix --config=.php-cs-fixer.dist.php --diff --verbose
```

on current `main` yields

```
tools/php-cs-fixer fix --config=.php-cs-fixer.dist.php --diff --verbose
PHP CS Fixer 3.14.3 (b418036) Oliva by Fabien Potencier and Dariusz Ruminski.
PHP runtime: 8.1.14
Loaded config default from ".php-cs-fixer.dist.php".
Using cache file ".php-cs-fixer.cache".
................                                                                                                                                                                                                                                                                                                16 / 16 (100%)
Legend: .-no changes, F-fixed, S-skipped (cached or empty file), I-invalid file syntax (file ignored), E-error

Fixed 0 of 16 files in 0.251 seconds, 16.578 MB memory used

Detected deprecations in use:
- Rule "no_trailing_comma_in_list_call" is deprecated. Use "no_trailing_comma_in_singleline" instead.
- Rule "no_trailing_comma_in_singleline_array" is deprecated. Use "no_trailing_comma_in_singleline" instead.
```

For reference, see https://github.com/PHP-CS-Fixer/PHP-CS-Fixer/blob/v3.14.3/doc/rules/basic/no_trailing_comma_in_singleline.rst.