### PR TITLE
Fix link in README: page is 404

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ $ phive install phpcov
 $ ./tools/phpcov --version
 ```
 
-**[It is not recommended to use Composer to download and install this tool.](https://phpunit.readthedocs.io/en/10.0/installation.html#phar-or-composer)**
+**[It is not recommended to use Composer to download and install this tool.](https://phpunit.readthedocs.io/en/11.0/installation.html#phar-or-composer)**
 
 ## Usage
 


### PR DESCRIPTION
The version in the URL needed to be updated. It would be best to point to `latest` or `stable`, but these are not tagged in readthedocs currently, so in the meantime, simply bump the version number.